### PR TITLE
Fix/#59 reset score

### DIFF
--- a/src/main/java/com/ducami/dukkaebi/domain/grading/service/JudgeService.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/grading/service/JudgeService.java
@@ -159,46 +159,59 @@ public class JudgeService {
         }
 
         // 기존 히스토리 조회 또는 새로 생성
-        ProblemHistory history = problemHistoryJpaRepo
-                .findByUser_IdAndProblem_ProblemId(user.getId(), problemId)
-                .orElse(ProblemHistory.builder()
+        Optional<ProblemHistory> existingHistory = problemHistoryJpaRepo
+                .findByUser_IdAndProblem_ProblemId(user.getId(), problemId);
+        boolean firstAttempt = existingHistory.isEmpty();
+
+        ProblemHistory history = existingHistory
+                .orElseGet(() -> ProblemHistory.builder()
                         .user(user)
                         .problem(problem)
                         .solvedResult(SolvedResult.NOT_SOLVED)
                         .build());
+        boolean firstSolve = finalStatus == JudgeStatus.ACCEPTED && history.isNotSolved();
 
 
         // 정답 처리 시 점수 부여 (일반 문제만 - 대회 문제는 별도 처리)
-        if (finalStatus == JudgeStatus.ACCEPTED && problem.getContestId() == null) {
-            if (history.isNotSolved()) {
-                Integer reward = difficultyToScore(problem.getDifficulty());
-                try {
-                    user.addScore(reward);
-                    // 일일 활동 1 증가 (정답 1건)
-                    userActivityService.increaseTodaySolvedCount(1);
-                    log.info("점수/활동 갱신 (일반 문제) - userId: {}, +{}점, 오늘 푼 문제 +1", user.getId(), reward);
-                } catch (Exception e) {
-                    log.error("점수/활동 갱신 실패: {}", e.getMessage(), e);
-                }
+        if (firstSolve && problem.getContestId() == null) {
+            Integer reward = difficultyToScore(problem.getDifficulty());
+            try {
+                user.addScore(reward);
+                // 일일 활동 1 증가 (정답 1건)
+                userActivityService.increaseTodaySolvedCount(1);
+                log.info("점수/활동 갱신 (일반 문제) - userId: {}, +{}점, 오늘 푼 문제 +1", user.getId(), reward);
+            } catch (Exception e) {
+                log.error("점수/활동 갱신 실패: {}", e.getMessage(), e);
             }
         }
 
         // Problem의 solvedCount, attemptCount 업데이트
-        if (history.isNotSolved()) {
-            try {
+        try {
+            boolean problemStatsChanged = false;
 
-                if (finalStatus == JudgeStatus.ACCEPTED) {
-                    problem.incrementSolvedCount();
-                    problem.incrementAttemptCount();
-                    problemJpaRepo.save(problem);
-                    log.info("Problem 통계 업데이트 - problemId: {}, solvedCount: {}, attemptCount: {}",
-                            problemId, problem.getSolvedCount(), problem.getAttemptCount());
-                }
-
-
-            } catch (Exception e) {
-                log.error("Problem 통계 업데이트 실패: {}", e.getMessage(), e);
+            // 일반 문제의 attemptCount는 제출 횟수가 아니라 한 번이라도 시도한 사용자 수다.
+            if (problem.getContestId() == null && firstAttempt) {
+                problem.incrementAttemptCount();
+                problemStatsChanged = true;
             }
+
+            if (firstSolve) {
+                problem.incrementSolvedCount();
+                problemStatsChanged = true;
+
+                // 대회 문제 통계는 기존 동작(최초 정답 시 시도/정답 동시 증가)을 유지한다.
+                if (problem.getContestId() != null) {
+                    problem.incrementAttemptCount();
+                }
+            }
+
+            if (problemStatsChanged) {
+                problemJpaRepo.save(problem);
+                log.info("Problem 통계 업데이트 - problemId: {}, solvedCount: {}, attemptCount: {}",
+                        problemId, problem.getSolvedCount(), problem.getAttemptCount());
+            }
+        } catch (Exception e) {
+            log.error("Problem 통계 업데이트 실패: {}", e.getMessage(), e);
         }
 
 

--- a/src/main/java/com/ducami/dukkaebi/domain/grading/service/JudgeService.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/grading/service/JudgeService.java
@@ -65,6 +65,10 @@ public class JudgeService {
         Problem problem = problemJpaRepo.findById(problemId)
                 .orElseThrow(() -> new IllegalArgumentException("문제를 찾을 수 없습니다."));
 
+        User sessionUser = userSessionHolder.getUser();
+        User user = userJpaRepo.findById(sessionUser.getId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
         // 2. 테스트케이스 조회
         List<ProblemTestCase> testCases = testCaseJpaRepo.findByProblem_ProblemId(problemId);
 
@@ -154,59 +158,64 @@ public class JudgeService {
             }
         }
 
+        // 기존 히스토리 조회 또는 새로 생성
+        ProblemHistory history = problemHistoryJpaRepo
+                .findByUser_IdAndProblem_ProblemId(user.getId(), problemId)
+                .orElse(ProblemHistory.builder()
+                        .user(user)
+                        .problem(problem)
+                        .solvedResult(SolvedResult.NOT_SOLVED)
+                        .build());
+
+
         // 정답 처리 시 점수 부여 (일반 문제만 - 대회 문제는 별도 처리)
         if (finalStatus == JudgeStatus.ACCEPTED && problem.getContestId() == null) {
-            Integer reward = difficultyToScore(problem.getDifficulty());
-            try {
-                User sessionUser = userSessionHolder.getUser();
-                User user = userJpaRepo.findById(sessionUser.getId())
-                        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-                user.addScore(reward);
-                // 일일 활동 1 증가 (정답 1건)
-                userActivityService.increaseTodaySolvedCount(1);
-                log.info("점수/활동 갱신 (일반 문제) - userId: {}, +{}점, 오늘 푼 문제 +1", user.getId(), reward);
-            } catch (Exception e) {
-                log.error("점수/활동 갱신 실패: {}", e.getMessage(), e);
+            if (history.isNotSolved()) {
+                Integer reward = difficultyToScore(problem.getDifficulty());
+                try {
+                    user.addScore(reward);
+                    // 일일 활동 1 증가 (정답 1건)
+                    userActivityService.increaseTodaySolvedCount(1);
+                    log.info("점수/활동 갱신 (일반 문제) - userId: {}, +{}점, 오늘 푼 문제 +1", user.getId(), reward);
+                } catch (Exception e) {
+                    log.error("점수/활동 갱신 실패: {}", e.getMessage(), e);
+                }
             }
         }
 
         // Problem의 solvedCount, attemptCount 업데이트
-        try {
-            problem.incrementAttemptCount();
-            if (finalStatus == JudgeStatus.ACCEPTED) {
-                problem.incrementSolvedCount();
+        if (history.isNotSolved()) {
+            try {
+
+                if (finalStatus == JudgeStatus.ACCEPTED) {
+                    problem.incrementSolvedCount();
+                    problem.incrementAttemptCount();
+                    problemJpaRepo.save(problem);
+                    log.info("Problem 통계 업데이트 - problemId: {}, solvedCount: {}, attemptCount: {}",
+                            problemId, problem.getSolvedCount(), problem.getAttemptCount());
+                }
+
+
+            } catch (Exception e) {
+                log.error("Problem 통계 업데이트 실패: {}", e.getMessage(), e);
             }
-            problemJpaRepo.save(problem);
-            log.info("Problem 통계 업데이트 - problemId: {}, solvedCount: {}, attemptCount: {}",
-                    problemId, problem.getSolvedCount(), problem.getAttemptCount());
-        } catch (Exception e) {
-            log.error("Problem 통계 업데이트 실패: {}", e.getMessage(), e);
         }
+
 
         // ProblemHistory 업데이트 (제출 여부 기록)
         try {
-            User sessionUser = userSessionHolder.getUser();
-            User user = userJpaRepo.findById(sessionUser.getId())
-                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            if (history.isNotSolved()) {
+                // 정답이면 SOLVED, 오답이면 FAILED로 업데이트
+                SolvedResult result = (finalStatus == JudgeStatus.ACCEPTED)
+                        ? SolvedResult.SOLVED
+                        : SolvedResult.FAILED;
+                history.updateSolvedResult(result);
 
-            // 기존 히스토리 조회 또는 새로 생성
-            ProblemHistory history = problemHistoryJpaRepo
-                    .findByUser_IdAndProblem_ProblemId(user.getId(), problemId)
-                    .orElse(ProblemHistory.builder()
-                            .user(user)
-                            .problem(problem)
-                            .solvedResult(SolvedResult.NOT_SOLVED)
-                            .build());
+                problemHistoryJpaRepo.save(history);
+                log.info("ProblemHistory 업데이트 - userId: {}, problemId: {}, result: {}",
+                        user.getId(), problemId, result);
+            }
 
-            // 정답이면 SOLVED, 오답이면 FAILED로 업데이트
-            SolvedResult result = (finalStatus == JudgeStatus.ACCEPTED)
-                    ? SolvedResult.SOLVED
-                    : SolvedResult.FAILED;
-            history.updateSolvedResult(result);
-
-            problemHistoryJpaRepo.save(history);
-            log.info("ProblemHistory 업데이트 - userId: {}, problemId: {}, result: {}",
-                    user.getId(), problemId, result);
         } catch (Exception e) {
             log.error("ProblemHistory 업데이트 실패: {}", e.getMessage(), e);
         }

--- a/src/main/java/com/ducami/dukkaebi/domain/problem/domain/ProblemHistory.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/problem/domain/ProblemHistory.java
@@ -32,4 +32,8 @@ public class ProblemHistory {
     public void updateSolvedResult(SolvedResult solvedResult) {
         this.solvedResult = solvedResult;
     }
+
+    public boolean isNotSolved() {
+        return !SolvedResult.SOLVED.equals(solvedResult);
+    }
 }

--- a/src/main/java/com/ducami/dukkaebi/global/common/service/S3Service.java
+++ b/src/main/java/com/ducami/dukkaebi/global/common/service/S3Service.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.ducami.dukkaebi.global.common.util.S3UrlUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -58,7 +59,7 @@ public class S3Service {
         }
 
         try {
-            String fileName = extractFileNameFromUrl(fileUrl);
+            String fileName = S3UrlUtil.extractFileNameFromUrl(fileUrl, bucketName);
             amazonS3Client.deleteObject(new DeleteObjectRequest(bucketName, fileName));
             log.info("S3 파일 삭제 성공: {}", fileName);
         } catch (Exception e) {
@@ -80,14 +81,4 @@ public class S3Service {
         }
         return folder + "/" + UUID.randomUUID() + extension;
     }
-
-    /**
-     * URL에서 파일명 추출
-     * @param fileUrl 파일 URL
-     * @return 추출된 파일명
-     */
-    private String extractFileNameFromUrl(String fileUrl) {
-        return fileUrl.substring(fileUrl.indexOf(bucketName) + bucketName.length() + 1);
-    }
 }
-

--- a/src/main/java/com/ducami/dukkaebi/global/common/util/S3UrlUtil.java
+++ b/src/main/java/com/ducami/dukkaebi/global/common/util/S3UrlUtil.java
@@ -1,0 +1,52 @@
+package com.ducami.dukkaebi.global.common.util;
+
+import java.net.URI;
+
+public final class S3UrlUtil {
+
+    private static final String AMAZON_AWS_DOMAIN = ".amazonaws.com";
+
+    private S3UrlUtil() {
+    }
+
+    public static String extractFileNameFromUrl(String fileUrl, String bucketName) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            throw new IllegalArgumentException("S3 URL은 비어 있을 수 없습니다.");
+        }
+
+        URI uri = URI.create(fileUrl);
+        String host = uri.getHost();
+        String path = uri.getPath();
+
+        if (host == null || path == null) {
+            throw new IllegalArgumentException("유효하지 않은 S3 URL입니다.");
+        }
+
+        if (isVirtualHostedStyle(host, bucketName)) {
+            return trimLeadingSlash(path);
+        }
+
+        if (isPathStyle(host, bucketName)) {
+            String prefix = "/" + bucketName + "/";
+            if (!path.startsWith(prefix)) {
+                throw new IllegalArgumentException("요청한 버킷과 URL이 일치하지 않습니다.");
+            }
+            return path.substring(prefix.length());
+        }
+
+        throw new IllegalArgumentException("요청한 버킷과 URL이 일치하지 않습니다.");
+    }
+
+    private static boolean isVirtualHostedStyle(String host, String bucketName) {
+        return host.startsWith(bucketName + ".s3.") && host.endsWith(AMAZON_AWS_DOMAIN);
+    }
+
+    private static boolean isPathStyle(String host, String bucketName) {
+        return host.startsWith("s3.") && host.endsWith(AMAZON_AWS_DOMAIN)
+                && !bucketName.isBlank();
+    }
+
+    private static String trimLeadingSlash(String path) {
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+}

--- a/src/test/java/com/ducami/dukkaebi/domain/grading/service/JudgeServiceTest.java
+++ b/src/test/java/com/ducami/dukkaebi/domain/grading/service/JudgeServiceTest.java
@@ -1,0 +1,234 @@
+package com.ducami.dukkaebi.domain.grading.service;
+
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestJpaRepo;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestParticipantJpaRepo;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestProblemScoreJpaRepo;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestSubmissionJpaRepo;
+import com.ducami.dukkaebi.domain.grading.domain.enums.JudgeStatus;
+import com.ducami.dukkaebi.domain.grading.model.ExecutionResult;
+import com.ducami.dukkaebi.domain.grading.presentation.dto.response.JudgeResultRes;
+import com.ducami.dukkaebi.domain.grading.util.CodeExecutor;
+import com.ducami.dukkaebi.domain.problem.domain.Problem;
+import com.ducami.dukkaebi.domain.problem.domain.ProblemHistory;
+import com.ducami.dukkaebi.domain.problem.domain.ProblemTestCase;
+import com.ducami.dukkaebi.domain.problem.domain.enums.DifficultyType;
+import com.ducami.dukkaebi.domain.problem.domain.enums.SolvedResult;
+import com.ducami.dukkaebi.domain.problem.domain.repo.ProblemHistoryJpaRepo;
+import com.ducami.dukkaebi.domain.problem.domain.repo.ProblemJpaRepo;
+import com.ducami.dukkaebi.domain.problem.domain.repo.ProblemTestCaseJpaRepo;
+import com.ducami.dukkaebi.domain.user.domain.User;
+import com.ducami.dukkaebi.domain.user.domain.enums.GrowthType;
+import com.ducami.dukkaebi.domain.user.domain.enums.UserType;
+import com.ducami.dukkaebi.domain.user.domain.repo.UserJpaRepo;
+import com.ducami.dukkaebi.domain.user.service.UserActivityService;
+import com.ducami.dukkaebi.global.security.auth.UserSessionHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JudgeServiceTest {
+
+    private static final Long PROBLEM_ID = 1L;
+    private static final Long USER_ID = 1L;
+    private static final String SOURCE_CODE = "print(42)";
+
+    @Mock
+    private ProblemJpaRepo problemJpaRepo;
+    @Mock
+    private ProblemTestCaseJpaRepo testCaseJpaRepo;
+    @Mock
+    private ProblemHistoryJpaRepo problemHistoryJpaRepo;
+    @Mock
+    private CodeExecutor codeExecutor;
+    @Mock
+    private UserSessionHolder userSessionHolder;
+    @Mock
+    private UserJpaRepo userJpaRepo;
+    @Mock
+    private UserActivityService userActivityService;
+    @Mock
+    private ContestParticipantJpaRepo contestParticipantJpaRepo;
+    @Mock
+    private ContestProblemScoreJpaRepo contestProblemScoreJpaRepo;
+    @Mock
+    private ContestSubmissionJpaRepo contestSubmissionJpaRepo;
+    @Mock
+    private ContestJpaRepo contestJpaRepo;
+
+    @InjectMocks
+    private JudgeService judgeService;
+
+    private Problem problem;
+    private User user;
+    private AtomicReference<ProblemHistory> storedHistory;
+
+    @BeforeEach
+    void setUp() {
+        problem = Problem.builder()
+                .problemId(PROBLEM_ID)
+                .name("테스트 문제")
+                .description("테스트 설명")
+                .input("입력")
+                .output("출력")
+                .difficulty(DifficultyType.COPPER)
+                .solvedCount(0)
+                .attemptCount(0)
+                .addedAt(LocalDate.now())
+                .build();
+
+        user = User.builder()
+                .id(USER_ID)
+                .loginId("student")
+                .password("password")
+                .nickname("학생")
+                .role(UserType.STUDENT)
+                .score(0)
+                .growth(GrowthType.WISP)
+                .build();
+
+        ProblemTestCase testCase = ProblemTestCase.builder()
+                .id(1L)
+                .problem(problem)
+                .input("")
+                .output("42")
+                .build();
+
+        storedHistory = new AtomicReference<>();
+
+        when(problemJpaRepo.findById(PROBLEM_ID)).thenReturn(Optional.of(problem));
+        when(testCaseJpaRepo.findByProblem_ProblemId(PROBLEM_ID)).thenReturn(List.of(testCase));
+        when(userSessionHolder.getUser()).thenReturn(user);
+        when(userJpaRepo.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(problemHistoryJpaRepo.findByUser_IdAndProblem_ProblemId(USER_ID, PROBLEM_ID))
+                .thenAnswer(ignored -> Optional.ofNullable(storedHistory.get()));
+        when(problemHistoryJpaRepo.save(any(ProblemHistory.class))).thenAnswer(invocation -> {
+            ProblemHistory history = invocation.getArgument(0);
+            storedHistory.set(history);
+            return history;
+        });
+    }
+
+    @Test
+    @DisplayName("첫 제출이 정답이면 SOLVED로 저장하고 최초 보상을 반영한다")
+    void firstAcceptedSubmissionStoresSolved() {
+        gradeAsAccepted();
+
+        JudgeResultRes result = judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+
+        assertThat(result.status()).isEqualTo(JudgeStatus.ACCEPTED);
+        assertThat(storedHistory.get().getSolvedResult()).isEqualTo(SolvedResult.SOLVED);
+        assertThat(problem.getSolvedCount()).isEqualTo(1);
+        assertThat(problem.getAttemptCount()).isEqualTo(1);
+        assertThat(user.getScore()).isEqualTo(1);
+        verify(userActivityService).increaseTodaySolvedCount(1);
+    }
+
+    @Test
+    @DisplayName("첫 제출이 오답이면 FAILED로 저장하고 최초 시도만 반영한다")
+    void firstWrongSubmissionStoresFailed() {
+        gradeAsWrongAnswer();
+
+        JudgeResultRes result = judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+
+        assertThat(result.status()).isEqualTo(JudgeStatus.WRONG_ANSWER);
+        assertThat(storedHistory.get().getSolvedResult()).isEqualTo(SolvedResult.FAILED);
+        assertThat(problem.getSolvedCount()).isZero();
+        assertThat(problem.getAttemptCount()).isEqualTo(1);
+        assertThat(user.getScore()).isZero();
+        verifyNoInteractions(userActivityService);
+    }
+
+    @Test
+    @DisplayName("오답 후 정답이면 FAILED를 SOLVED로 변경하고 보상을 한 번만 반영한다")
+    void acceptedAfterWrongStoresSolved() {
+        when(codeExecutor.execute(anyString(), anyString(), anyString(), anyLong()))
+                .thenReturn(wrongAnswer(), accepted());
+
+        JudgeResultRes wrongResult = judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+        JudgeResultRes acceptedResult = judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+
+        assertThat(wrongResult.status()).isEqualTo(JudgeStatus.WRONG_ANSWER);
+        assertThat(acceptedResult.status()).isEqualTo(JudgeStatus.ACCEPTED);
+        assertThat(storedHistory.get().getSolvedResult()).isEqualTo(SolvedResult.SOLVED);
+        assertThat(problem.getSolvedCount()).isEqualTo(1);
+        assertThat(problem.getAttemptCount()).isEqualTo(1);
+        assertThat(user.getScore()).isEqualTo(1);
+        verify(userActivityService).increaseTodaySolvedCount(1);
+        verify(problemHistoryJpaRepo, times(2)).save(any(ProblemHistory.class));
+    }
+
+    @Test
+    @DisplayName("정답 후 오답을 제출해도 저장된 SOLVED 상태를 FAILED로 내리지 않는다")
+    void wrongAfterAcceptedKeepsSolved() {
+        when(codeExecutor.execute(anyString(), anyString(), anyString(), anyLong()))
+                .thenReturn(accepted(), wrongAnswer());
+
+        JudgeResultRes acceptedResult = judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+        JudgeResultRes wrongResult = judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+
+        assertThat(acceptedResult.status()).isEqualTo(JudgeStatus.ACCEPTED);
+        assertThat(wrongResult.status()).isEqualTo(JudgeStatus.WRONG_ANSWER);
+        assertThat(storedHistory.get().getSolvedResult()).isEqualTo(SolvedResult.SOLVED);
+        assertThat(problem.getSolvedCount()).isEqualTo(1);
+        assertThat(problem.getAttemptCount()).isEqualTo(1);
+        assertThat(user.getScore()).isEqualTo(1);
+        verify(userActivityService).increaseTodaySolvedCount(1);
+        verify(problemHistoryJpaRepo).save(any(ProblemHistory.class));
+    }
+
+    @Test
+    @DisplayName("정답 후 계속 정답을 제출해도 시도 사용자 수와 오늘 기여도는 증가하지 않는다")
+    void repeatedAcceptedSubmissionsDoNotIncreaseCounts() {
+        when(codeExecutor.execute(anyString(), anyString(), anyString(), anyLong()))
+                .thenReturn(accepted(), accepted(), accepted());
+
+        judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+        judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+        judgeService.judgeCode(PROBLEM_ID, SOURCE_CODE, "python", null);
+
+        assertThat(storedHistory.get().getSolvedResult()).isEqualTo(SolvedResult.SOLVED);
+        assertThat(problem.getSolvedCount()).isEqualTo(1);
+        assertThat(problem.getAttemptCount()).isEqualTo(1);
+        assertThat(user.getScore()).isEqualTo(1);
+        verify(userActivityService).increaseTodaySolvedCount(1);
+        verify(problemJpaRepo).save(problem);
+        verify(problemHistoryJpaRepo).save(any(ProblemHistory.class));
+    }
+
+    private void gradeAsAccepted() {
+        when(codeExecutor.execute(anyString(), anyString(), anyString(), anyLong()))
+                .thenReturn(accepted());
+    }
+
+    private void gradeAsWrongAnswer() {
+        when(codeExecutor.execute(anyString(), anyString(), anyString(), anyLong()))
+                .thenReturn(wrongAnswer());
+    }
+
+    private ExecutionResult accepted() {
+        return new ExecutionResult("42", "", true, false);
+    }
+
+    private ExecutionResult wrongAnswer() {
+        return new ExecutionResult("0", "", true, false);
+    }
+}

--- a/src/test/java/com/ducami/dukkaebi/global/common/service/S3ServiceTest.java
+++ b/src/test/java/com/ducami/dukkaebi/global/common/service/S3ServiceTest.java
@@ -1,0 +1,41 @@
+package com.ducami.dukkaebi.global.common.service;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class S3ServiceTest {
+    private static final String BUCKET_NAME = "dukkaebi-assets";
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://dukkaebi-assets.s3.ap-northeast-2.amazonaws.com/notice/image.png",
+            "https://s3.ap-northeast-2.amazonaws.com/dukkaebi-assets/notice/image.png"
+    })
+    void extractsKeyFromSupportedS3UrlStyles(String fileUrl) {
+        S3Service service = createService();
+
+        assertThat(service.extractFileNameFromUrl(fileUrl)).isEqualTo("notice/image.png");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://other-bucket.s3.ap-northeast-2.amazonaws.com/notice/image.png",
+            "https://example.com/dukkaebi-assets/notice/image.png"
+    })
+    void rejectsUrlOutsideConfiguredBucket(String fileUrl) {
+        S3Service service = createService();
+
+        assertThatThrownBy(() -> service.extractFileNameFromUrl(fileUrl))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private S3Service createService() {
+        S3Service service = new S3Service(null);
+        ReflectionTestUtils.setField(service, "bucketName", BUCKET_NAME);
+        return service;
+    }
+}

--- a/src/test/java/com/ducami/dukkaebi/global/common/service/S3ServiceTest.java
+++ b/src/test/java/com/ducami/dukkaebi/global/common/service/S3ServiceTest.java
@@ -1,8 +1,8 @@
 package com.ducami.dukkaebi.global.common.service;
 
+import com.ducami.dukkaebi.global.common.util.S3UrlUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,9 +16,7 @@ class S3ServiceTest {
             "https://s3.ap-northeast-2.amazonaws.com/dukkaebi-assets/notice/image.png"
     })
     void extractsKeyFromSupportedS3UrlStyles(String fileUrl) {
-        S3Service service = createService();
-
-        assertThat(service.extractFileNameFromUrl(fileUrl)).isEqualTo("notice/image.png");
+        assertThat(S3UrlUtil.extractFileNameFromUrl(fileUrl, BUCKET_NAME)).isEqualTo("notice/image.png");
     }
 
     @ParameterizedTest
@@ -27,15 +25,7 @@ class S3ServiceTest {
             "https://example.com/dukkaebi-assets/notice/image.png"
     })
     void rejectsUrlOutsideConfiguredBucket(String fileUrl) {
-        S3Service service = createService();
-
-        assertThatThrownBy(() -> service.extractFileNameFromUrl(fileUrl))
+        assertThatThrownBy(() -> S3UrlUtil.extractFileNameFromUrl(fileUrl, BUCKET_NAME))
                 .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    private S3Service createService() {
-        S3Service service = new S3Service(null);
-        ReflectionTestUtils.setField(service, "bucketName", BUCKET_NAME);
-        return service;
     }
 }

--- a/src/test/java/com/ducami/dukkaebi/global/config/SpringConfigTest.java
+++ b/src/test/java/com/ducami/dukkaebi/global/config/SpringConfigTest.java
@@ -1,0 +1,21 @@
+package com.ducami.dukkaebi.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class SpringConfigTest {
+    @Test
+    void doesNotExposeLocalResourcesWhenUsingS3Storage() {
+        SpringConfig config = new SpringConfig();
+        ReflectionTestUtils.setField(config, "storageProvider", "s3");
+        ResourceHandlerRegistry registry = mock(ResourceHandlerRegistry.class);
+
+        config.addResourceHandlers(registry);
+
+        verifyNoInteractions(registry);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
- Resolves #59 

## 변경 내용
<!-- 어떤 변경을 했는지 설명해주세요 -->
- S3Service의 url extract를 Util로 분리
- 채점 시 기존 히스토리가 solve인 경우 실패 해도 그 값이 변경되지 않음
- 채점 시 기존 히스토리가 solve인 경우 성공해도 성공 횟수와 일일 스트릭이 늘지 않음
- 첫번 째 시도일 때만 시도 횟수가 증가하도록 수정

## 작업 목적
<!-- 왜 이 변경이 필요한지 설명해주세요 -->
- 결과가 solve인 경우에도 마지막 채점 결과를 반영하기 때문에 데이터가 잘못되는 문제를 해결함

## 테스트 방법
<!-- 변경 사항을 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] Breaking Changes가 없습니다

## 기타 사항
<!-- 리뷰어에게 전달할 내용이 있으면 작성해주세요 -->