### PR TITLE
Fix/#63 contest status

### DIFF
--- a/src/main/java/com/ducami/dukkaebi/domain/contest/domain/enums/ContestStatus.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/contest/domain/enums/ContestStatus.java
@@ -1,8 +1,8 @@
 package com.ducami.dukkaebi.domain.contest.domain.enums;
 
 public enum ContestStatus {
-    JOINABLE, // 참여하기
-    JOINED,   // 참여중
-    ENDED     // 대회종료
+    UPCOMING,
+    ONGOING,
+    ENDED
 }
 

--- a/src/main/java/com/ducami/dukkaebi/domain/contest/domain/repo/ContestParticipantJpaRepo.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/contest/domain/repo/ContestParticipantJpaRepo.java
@@ -11,8 +11,9 @@ import java.util.Optional;
 public interface ContestParticipantJpaRepo extends JpaRepository<ContestParticipant, Long> {
     List<ContestParticipant> findByContest_CodeOrderByTotalScoreDescTotalTimeSecondsAsc(String contestCode);
     Optional<ContestParticipant> findByContest_CodeAndUser_Id(String contestCode, Long userId);
+
+    List<ContestParticipant> findAllByContest_CodeInAndUser_Id(List<String> contestCodes, Long userId);
     boolean existsByContest_CodeAndUser_Id(String contestCode, Long userId);
     List<ContestParticipant> findByUser_Id(Long userId);
     int deleteByUser_Id(Long userId);
 }
-

--- a/src/main/java/com/ducami/dukkaebi/domain/contest/presentation/dto/request/ContestReq.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/contest/presentation/dto/request/ContestReq.java
@@ -22,7 +22,7 @@ public record ContestReq(
                 .imageUrl(req.imageUrl)
                 .startDate(req.startDate)
                 .endDate(req.endDate)
-                .status(ContestStatus.JOINABLE)
+                .status(ContestStatus.UPCOMING)
                 .participantIds(new ArrayList<>(List.of()))
                 .build();
     }

--- a/src/main/java/com/ducami/dukkaebi/domain/contest/presentation/dto/response/ContestDetailRes.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/contest/presentation/dto/response/ContestDetailRes.java
@@ -17,6 +17,7 @@ public record ContestDetailRes(
         LocalDateTime startDate,
         LocalDateTime endDate,
         ContestStatus status,
+        boolean joined,
         Integer participantCount,
         List<ProblemRes> problems
 ) {
@@ -24,20 +25,22 @@ public record ContestDetailRes(
 
     public static ContestDetailRes from(Contest contest, List<ProblemRes> problems, Long userId) {
         Integer participantCount = contest.getParticipantIds() == null ? 0 : contest.getParticipantIds().size();
+        boolean joined = userId != null && contest.hasParticipant(userId);
 
         // Contest에 status가 명시되어 있으면 우선 사용 (관리자가 강제 종료한 경우)
         ContestStatus status = contest.getStatus();
         if (status != ContestStatus.ENDED) {
             LocalDateTime now = LocalDateTime.now(ZONE);
             LocalDateTime end = contest.getEndDate();
+            LocalDateTime start = contest.getStartDate();
 
             // 날짜로 종료 여부 판단
-            if (end != null && end.isBefore(now)) {
+            if (end != null && !end.isAfter(now)) {
                 status = ContestStatus.ENDED;
-            } else if (contest.getParticipantIds() != null && userId != null && contest.getParticipantIds().contains(userId)) {
-                status = ContestStatus.JOINED;
+            } else if (start != null && !start.isAfter(now)) {
+                status = ContestStatus.ONGOING;
             } else {
-                status = ContestStatus.JOINABLE;
+                status = ContestStatus.UPCOMING;
             }
         }
 
@@ -49,6 +52,7 @@ public record ContestDetailRes(
                 .startDate(contest.getStartDate())
                 .endDate(contest.getEndDate())
                 .status(status)
+                .joined(joined)
                 .participantCount(participantCount)
                 .problems(problems)
                 .build();

--- a/src/main/java/com/ducami/dukkaebi/domain/contest/presentation/dto/response/ContestListRes.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/contest/presentation/dto/response/ContestListRes.java
@@ -13,13 +13,15 @@ public record ContestListRes(
         String imageUrl,
         String dDay,
         Integer participantCount,
-        ContestStatus status
+        ContestStatus status,
+        boolean joined
 ) {
     private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
 
-    public static ContestListRes from(Contest contest, Long userId) {
+    public static ContestListRes from(Contest contest, boolean joined) {
         LocalDateTime now = LocalDateTime.now(ZONE);
         LocalDateTime end = contest.getEndDate();
+        LocalDateTime start = contest.getStartDate();
         String dDayStr;
 
         if (end == null) {
@@ -41,15 +43,23 @@ public record ContestListRes(
         ContestStatus status = contest.getStatus();
         if (status != ContestStatus.ENDED) {
             // 날짜로 종료 여부 판단
-            if (end != null && end.isBefore(now)) {
+            if (end != null && !end.isAfter(now)) {
                 status = ContestStatus.ENDED;
-            } else if (contest.getParticipantIds() != null && userId != null && contest.getParticipantIds().contains(userId)) {
-                status = ContestStatus.JOINED;
+            } else if (start != null && !start.isAfter(now)) {
+                status = ContestStatus.ONGOING;
             } else {
-                status = ContestStatus.JOINABLE;
+                status = ContestStatus.UPCOMING;
             }
         }
 
-        return new ContestListRes(contest.getCode(), contest.getTitle(), contest.getImageUrl(), dDayStr, count, status);
+        return new ContestListRes(
+                contest.getCode(),
+                contest.getTitle(),
+                contest.getImageUrl(),
+                dDayStr,
+                count,
+                status,
+                joined
+        );
     }
 }

--- a/src/main/java/com/ducami/dukkaebi/domain/contest/usecase/ContestUseCase.java
+++ b/src/main/java/com/ducami/dukkaebi/domain/contest/usecase/ContestUseCase.java
@@ -41,6 +41,10 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -72,9 +76,11 @@ public class ContestUseCase {
         Long userId = userSessionHolder.getUserId();
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<ContestListRes> contestPage = contestJpaRepo.findAllByOrderByEndDateAsc(pageable)
-                .map(contest -> ContestListRes.from(contest, userId));
-        return PageResponse.of(contestPage);
+        Page<Contest> contestPage = contestJpaRepo.findAllByOrderByEndDateAsc(pageable);
+
+        Page<ContestListRes> contestResPage = mapContestPageToRes(contestPage, userId);
+
+        return PageResponse.of(contestResPage);
     }
 
     @Transactional(readOnly = true)
@@ -115,9 +121,10 @@ public class ContestUseCase {
         Long userId = userSessionHolder.getUserId();
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<ContestListRes> contestPage = contestJpaRepo.findByTitleContainingIgnoreCaseOrderByEndDateAsc(name, pageable)
-                .map(contest -> ContestListRes.from(contest, userId));
-        return PageResponse.of(contestPage);
+        Page<Contest> contestPage = contestJpaRepo.findByTitleContainingIgnoreCaseOrderByEndDateAsc(name, pageable);
+
+        Page<ContestListRes> contestResPage = mapContestPageToRes(contestPage, userId);
+        return PageResponse.of(contestResPage);
     }
 
     // 관리자
@@ -613,6 +620,29 @@ public class ContestUseCase {
         List<ProblemTestCase> testCases = problemTestCaseJpaRepo.findByProblem_ProblemId(problemId);
 
         return ContestSubmissionRes.from(submission, testCases);
+    }
+
+    private Page<ContestListRes> mapContestPageToRes(Page<Contest> contestPage, Long userId) {
+        // 1. contest Code 추출
+        List<String> contestIds = contestPage.getContent().stream()
+                .map(Contest::getCode)
+                .toList();
+
+        // 2. 사용자의 대회 참가 목록 조회
+        List<ContestParticipant> participants = contestIds.isEmpty()
+                ? List.of()
+                : contestParticipantJpaRepo.findAllByContest_CodeInAndUser_Id(contestIds, userId);
+
+        // 3. 대회 코드 기준으로 Map으로 변경
+        Map<String, ContestParticipant> participantMap = participants.stream()
+                .collect(Collectors.toMap(
+                        p -> p.getContest().getCode(),
+                        Function.identity() // p -> p
+                ));
+
+        return contestPage.map(contest ->
+                ContestListRes.from(contest, participantMap.containsKey(contest.getCode()))
+        );
     }
 
     // 시간 포맷팅 (초 -> HH:MM:SS)

--- a/src/test/java/com/ducami/dukkaebi/domain/contest/usecase/ContestUseCaseTest.java
+++ b/src/test/java/com/ducami/dukkaebi/domain/contest/usecase/ContestUseCaseTest.java
@@ -1,0 +1,243 @@
+package com.ducami.dukkaebi.domain.contest.usecase;
+
+import com.ducami.dukkaebi.domain.contest.domain.Contest;
+import com.ducami.dukkaebi.domain.contest.domain.ContestParticipant;
+import com.ducami.dukkaebi.domain.contest.domain.enums.ContestStatus;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestJpaRepo;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestParticipantJpaRepo;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestProblemMappingJpaRepo;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestProblemScoreJpaRepo;
+import com.ducami.dukkaebi.domain.contest.domain.repo.ContestSubmissionJpaRepo;
+import com.ducami.dukkaebi.domain.contest.presentation.dto.response.ContestListRes;
+import com.ducami.dukkaebi.domain.contest.service.ContestSseService;
+import com.ducami.dukkaebi.domain.contest.util.CodeGenerator;
+import com.ducami.dukkaebi.domain.grading.domain.repo.SavedCodeJpaRepo;
+import com.ducami.dukkaebi.domain.problem.domain.repo.ProblemHistoryJpaRepo;
+import com.ducami.dukkaebi.domain.problem.domain.repo.ProblemJpaRepo;
+import com.ducami.dukkaebi.domain.problem.domain.repo.ProblemTestCaseJpaRepo;
+import com.ducami.dukkaebi.global.common.dto.response.PageResponse;
+import com.ducami.dukkaebi.global.security.auth.UserSessionHolder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ContestUseCaseTest {
+
+    private static final long USER_ID = 42L;
+    private static final int PAGE = 0;
+    private static final int SIZE = 12;
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 7, 22, 12, 0);
+
+    @Mock
+    private ContestJpaRepo contestJpaRepo;
+    @Mock
+    private ContestParticipantJpaRepo contestParticipantJpaRepo;
+    @Mock
+    private ContestProblemScoreJpaRepo contestProblemScoreJpaRepo;
+    @Mock
+    private ContestSubmissionJpaRepo contestSubmissionJpaRepo;
+    @Mock
+    private ContestProblemMappingJpaRepo contestProblemMappingJpaRepo;
+    @Mock
+    private CodeGenerator codeGenerator;
+    @Mock
+    private UserSessionHolder userSessionHolder;
+    @Mock
+    private ProblemJpaRepo problemJpaRepo;
+    @Mock
+    private ProblemHistoryJpaRepo problemHistoryJpaRepo;
+    @Mock
+    private ProblemTestCaseJpaRepo problemTestCaseJpaRepo;
+    @Mock
+    private SavedCodeJpaRepo savedCodeJpaRepo;
+    @Mock
+    private ContestSseService contestSseService;
+
+    @InjectMocks
+    private ContestUseCase contestUseCase;
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("statusBoundaryCases")
+    @DisplayName("대회 목록 상태는 시작일과 종료일 경계값에 따라 결정된다")
+    void determinesStatusAtDateBoundaries(
+            String scenario,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            ContestStatus expectedStatus
+    ) {
+        Contest contest = contest("contest", startDate, endDate, ContestStatus.UPCOMING);
+        stubContestPage(List.of(contest));
+        when(contestParticipantJpaRepo.findAllByContest_CodeInAndUser_Id(List.of("contest"), USER_ID))
+                .thenReturn(List.of());
+
+        ContestListRes result = getContestListAtFixedNow().getContent().getFirst();
+
+        assertThat(result.status()).as(scenario).isEqualTo(expectedStatus);
+    }
+
+    @Test
+    @DisplayName("관리자가 종료한 대회는 날짜와 관계없이 ENDED 상태로 조회된다")
+    void forcedEndedStatusTakesPrecedenceOverDates() {
+        Contest contest = contest(
+                "forced-ended",
+                FIXED_NOW.plusDays(1),
+                FIXED_NOW.plusDays(2),
+                ContestStatus.ENDED
+        );
+        stubContestPage(List.of(contest));
+        when(contestParticipantJpaRepo.findAllByContest_CodeInAndUser_Id(List.of("forced-ended"), USER_ID))
+                .thenReturn(List.of());
+
+        ContestListRes result = getContestListAtFixedNow().getContent().getFirst();
+
+        assertThat(result.status()).isEqualTo(ContestStatus.ENDED);
+    }
+
+    @Test
+    @DisplayName("참가 기록이 있는 대회만 joined가 true로 조회된다")
+    void mapsJoinedStatusByContestParticipation() {
+        Contest notJoinedContest = ongoingContest("not-joined");
+        Contest joinedContest = ongoingContest("joined");
+        ContestParticipant participant = ContestParticipant.builder()
+                .id(1L)
+                .contest(joinedContest)
+                .totalScore(0)
+                .totalTimeSeconds(0)
+                .joinedAt(FIXED_NOW.minusHours(1))
+                .build();
+
+        stubContestPage(List.of(notJoinedContest, joinedContest));
+        when(contestParticipantJpaRepo.findAllByContest_CodeInAndUser_Id(
+                List.of("not-joined", "joined"), USER_ID
+        )).thenReturn(List.of(participant));
+
+        PageResponse<ContestListRes> result = getContestListAtFixedNow();
+
+        assertThat(result.getContent())
+                .extracting(ContestListRes::code, ContestListRes::joined)
+                .containsExactly(
+                        tuple("not-joined", false),
+                        tuple("joined", true)
+                );
+        assertThat(result.getCurrentPage()).isEqualTo(PAGE);
+        assertThat(result.getSize()).isEqualTo(SIZE);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("대회 목록이 비어 있으면 빈 페이지를 반환하고 참가 기록을 조회하지 않는다")
+    void returnsEmptyPageWithoutLookingUpParticipants() {
+        stubContestPage(List.of());
+
+        PageResponse<ContestListRes> result = getContestListAtFixedNow();
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verifyNoInteractions(contestParticipantJpaRepo);
+    }
+
+    private static Stream<Arguments> statusBoundaryCases() {
+        return Stream.of(
+                Arguments.of(
+                        "시작 시각을 1ns 지난 대회는 ONGOING이다",
+                        FIXED_NOW.minusNanos(1),
+                        FIXED_NOW.plusDays(1),
+                        ContestStatus.ONGOING
+                ),
+                Arguments.of(
+                        "시작 시각과 현재 시각이 같으면 ONGOING이다",
+                        FIXED_NOW,
+                        FIXED_NOW.plusDays(1),
+                        ContestStatus.ONGOING
+                ),
+                Arguments.of(
+                        "시작 시각이 1ns 남은 대회는 UPCOMING이다",
+                        FIXED_NOW.plusNanos(1),
+                        FIXED_NOW.plusDays(1),
+                        ContestStatus.UPCOMING
+                ),
+                Arguments.of(
+                        "종료 시각을 1ns 지난 대회는 ENDED이다",
+                        FIXED_NOW.minusDays(1),
+                        FIXED_NOW.minusNanos(1),
+                        ContestStatus.ENDED
+                ),
+                Arguments.of(
+                        "종료 시각과 현재 시각이 같으면 ENDED이다",
+                        FIXED_NOW.minusDays(1),
+                        FIXED_NOW,
+                        ContestStatus.ENDED
+                ),
+                Arguments.of(
+                        "종료 시각이 1ns 남은 대회는 ONGOING이다",
+                        FIXED_NOW.minusDays(1),
+                        FIXED_NOW.plusNanos(1),
+                        ContestStatus.ONGOING
+                )
+        );
+    }
+
+    private Contest ongoingContest(String code) {
+        return contest(
+                code,
+                FIXED_NOW.minusDays(1),
+                FIXED_NOW.plusDays(1),
+                ContestStatus.UPCOMING
+        );
+    }
+
+    private Contest contest(
+            String code,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            ContestStatus status
+    ) {
+        return Contest.builder()
+                .code(code)
+                .title(code + " 대회")
+                .description("테스트 대회")
+                .startDate(startDate)
+                .endDate(endDate)
+                .status(status)
+                .participantIds(List.of())
+                .problemIds(List.of())
+                .build();
+    }
+
+    private void stubContestPage(List<Contest> contests) {
+        PageRequest pageRequest = PageRequest.of(PAGE, SIZE);
+        when(userSessionHolder.getUserId()).thenReturn(USER_ID);
+        when(contestJpaRepo.findAllByOrderByEndDateAsc(pageRequest))
+                .thenReturn(new PageImpl<>(contests, pageRequest, contests.size()));
+    }
+
+    private PageResponse<ContestListRes> getContestListAtFixedNow() {
+        try (MockedStatic<LocalDateTime> localDateTime = mockStatic(LocalDateTime.class, CALLS_REAL_METHODS)) {
+            localDateTime.when(() -> LocalDateTime.now(SEOUL_ZONE)).thenReturn(FIXED_NOW);
+            return contestUseCase.getContestListPaged(PAGE, SIZE);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
- Resolves #63 

## 변경 내용
<!-- 어떤 변경을 했는지 설명해주세요 -->
- 대회 상태를 `UPCOMING`, `ONGOING`, `ENDED` 로 변경
- 대회 조회 시 사용자의 참여 여부 추가

## 작업 목적
<!-- 왜 이 변경이 필요한지 설명해주세요 -->
- 기존 대회 상태에서는 프론트에서 값 계산에 어려움이 있었음

## 스크린샷 (UI 변경 시)
<!-- UI 변경이 없다면 이 섹션을 삭제해주세요 -->

| Before | After |
|--------|-------|
|        |       |

## 테스트 방법
<!-- 변경 사항을 어떻게 테스트했는지 설명해주세요 -->
- [ ] 대회 상태를 경계값 분석으로 진행
- [ ] 대회 참가 여부를 동등 분할로 진행

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] Breaking Changes가 없습니다

## 기타 사항
<!-- 리뷰어에게 전달할 내용이 있으면 작성해주세요 -->